### PR TITLE
Fix panic test bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
-FROM arturolang/arturo
+FROM nimlang/nim:2.2.0-ubuntu
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y jq && \
+    apt-get install -y jq build-essential git libgtk-3-dev libwebkit2gtk-4.0-dev libmpfr-dev && \
     apt-get purge --auto-remove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/arturo-lang/arturo.git
+
+RUN cd arturo && ./build.nims build --install --log && \
+    cd .. && rm -rf arturo
+
+ENV PATH="/root/.arturo/bin:${PATH}"
 
 RUN arturo --package install unitt
 

--- a/tests/panic-fails/.meta/config.json
+++ b/tests/panic-fails/.meta/config.json
@@ -1,0 +1,23 @@
+{
+    "authors": [
+      "BNAndras"
+    ],
+    "files": {
+      "solution": [
+        "src/panic-fails.art"
+      ],
+      "test": [
+        "tests/test-panic-fails.art"
+      ],
+      "example": [
+        ".meta/src/example.art"
+      ],
+      "invalidator": [
+        "tester.art"
+      ]
+    },
+    "blurb": "Determine whether a given year is a leap year.",
+    "source": "CodeRanch Cattle Drive, Assignment 3",
+    "source_url": "https://coderanch.com/t/718816/Leap"
+  }
+  

--- a/tests/panic-fails/expected_results.json
+++ b/tests/panic-fails/expected_results.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "status": "fail",
+  "message": "\n===== tests/test-panic-fails.art =====\n\nSuite: Panic fails a test suite \n \n\u001b[0;33m    ✅ - assert that alwaysTrue passes because implemented\u001b[0m \n         assertion: true\n\n\n\u001b[0;31m══╡ \u001b[1;31mProgram Error\u001b[0;31m ╞═════════════════════════════════════════════════ <script> ══\u001b[0m\n\n  This function is in fact panicking\n\n\n\n===== Statistics =====\n\n⏏️    TOTAL: 1 assertions\n✅  PASSED: 1 assertions\n⏩ SKIPPED: 0 assertions\n❌  FAILED: 0 assertions\n\n===== ========== =====\n\n\n\u001b[0;31m══╡ \u001b[1;31mProgram Error\u001b[0;31m ╞═════════════════════════════════════════════════ <script> ══\u001b[0m\n\n  Some tests failed!"
+}

--- a/tests/panic-fails/src/panic-fails.art
+++ b/tests/panic-fails/src/panic-fails.art
@@ -1,0 +1,7 @@
+alwaysTrue: function [][
+    true
+]
+
+shouldNotPanic: function [][
+    panic "This function is in fact panicking"
+]

--- a/tests/panic-fails/tester.art
+++ b/tests/panic-fails/tester.art
@@ -1,0 +1,3 @@
+import {unitt}! 
+
+runTests.failFast findTests "tests"

--- a/tests/panic-fails/tests/test-panic-fails.art
+++ b/tests/panic-fails/tests/test-panic-fails.art
@@ -1,0 +1,13 @@
+import {unitt}!
+import {src/panic-fails}!
+
+suite "Panic fails a test suite" [
+    test "alwaysTrue passes because implemented" [
+        result: alwaysTrue
+        assert -> result
+    ]
+
+    test "shouldNotPanic does not pass" [
+        assert -> shouldNotPanic
+    ]
+]


### PR DESCRIPTION
This addreses an issue where until recently, a `panic` in Arturo defaulted to exit code 0. That meant a student could pass a test suite by adding a single whitespace to the exercise stub which contained panics the student would replace inside each function.

I took the `arturolang/arturo` Dockerfile and merged it with ours so we can have more control over how fresh of an Arturo nightly is being used. Therefore, this is a good time to apply some best practices to this Docker image in case I (very likely) missed something.