### PR TITLE
Set unitt version to 1.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN cd arturo && ./build.nims build --install --log && \
 
 ENV PATH="/root/.arturo/bin:${PATH}"
 
-RUN arturo --package install unitt
+RUN arturo --package install unitt 1.1.2
 
 WORKDIR /opt/test-runner
 COPY bin/run.sh bin/run.sh

--- a/tests/all-fail/tester.art
+++ b/tests/all-fail/tester.art
@@ -1,3 +1,3 @@
-import {unitt}! 
+import.version:1.1.2 {unitt}!  
 
 runTests.failFast findTests "tests"

--- a/tests/all-fail/tests/test-all-fail.art
+++ b/tests/all-fail/tests/test-all-fail.art
@@ -1,4 +1,4 @@
-import {unitt}!
+import.version:1.1.2 {unitt}! 
 import {src/all-fail}!
 
 suite "Leap" [

--- a/tests/empty-file/tester.art
+++ b/tests/empty-file/tester.art
@@ -1,3 +1,3 @@
-import {unitt}! 
+import.version:1.1.2 {unitt}!  
 
 runTests.failFast findTests "tests"

--- a/tests/empty-file/tests/test-empty-file.art
+++ b/tests/empty-file/tests/test-empty-file.art
@@ -1,4 +1,4 @@
-import {unitt}!
+import.version:1.1.2 {unitt}! 
 import {src/empty-file}!
 
 suite "Leap" [

--- a/tests/panic-fails/tester.art
+++ b/tests/panic-fails/tester.art
@@ -1,3 +1,3 @@
-import {unitt}! 
+import.version:1.1.2 {unitt}!  
 
 runTests.failFast findTests "tests"

--- a/tests/panic-fails/tests/test-panic-fails.art
+++ b/tests/panic-fails/tests/test-panic-fails.art
@@ -1,4 +1,4 @@
-import {unitt}!
+import.version:1.1.2 {unitt}! 
 import {src/panic-fails}!
 
 suite "Panic fails a test suite" [

--- a/tests/partial-fail/tester.art
+++ b/tests/partial-fail/tester.art
@@ -1,3 +1,3 @@
-import {unitt}! 
+import.version:1.1.2 {unitt}!  
 
 runTests.failFast findTests "tests"

--- a/tests/partial-fail/tests/test-partial-fail.art
+++ b/tests/partial-fail/tests/test-partial-fail.art
@@ -1,4 +1,4 @@
-import {unitt}!
+import.version:1.1.2 {unitt}! 
 import {src/partial-fail}!
 
 suite "Leap" [

--- a/tests/success/tester.art
+++ b/tests/success/tester.art
@@ -1,3 +1,3 @@
-import {unitt}! 
+import.version:1.1.2 {unitt}!  
 
 runTests.failFast findTests "tests"

--- a/tests/success/tests/test-success.art
+++ b/tests/success/tests/test-success.art
@@ -1,4 +1,4 @@
-import {unitt}!
+import.version:1.1.2 {unitt}! 
 import {src/success}!
 
 suite "Leap" [

--- a/tests/syntax-error/tester.art
+++ b/tests/syntax-error/tester.art
@@ -1,3 +1,3 @@
-import {unitt}! 
+import.version:1.1.2 {unitt}!  
 
 runTests.failFast findTests "tests"

--- a/tests/syntax-error/tests/test-syntax-error.art
+++ b/tests/syntax-error/tests/test-syntax-error.art
@@ -1,4 +1,4 @@
-import {unitt}!
+import.version:1.1.2 {unitt}! 
 import {src/syntax-error}!
 
 suite "Leap" [


### PR DESCRIPTION
Unitt is about to go through a major update. Setting a specific unitt version will make sure we're consistently grabbing the expected version. Exercise files will also need to be updated to specify the unitt version but won't break solutions.